### PR TITLE
Added support for autocompleting commit messages using LLMs

### DIFF
--- a/cmd/genCommit.go
+++ b/cmd/genCommit.go
@@ -9,6 +9,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var UseLLM bool
+
 var genCommitCmd = &cobra.Command{
 	Use:     "gen-commit",
 	Short:   "Generate a Conventional Commit message",
@@ -16,7 +18,7 @@ var genCommitCmd = &cobra.Command{
 	Aliases: []string{"gc"},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		theme := huh.ThemeCatppuccin()
-		commitMsg, err := commit.NewCommitMessage(theme)
+		commitMsg, err := commit.NewCommitMessage(theme, UseLLM)
 		if err != nil {
 			return err
 		}
@@ -33,4 +35,5 @@ var genCommitCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(genCommitCmd)
+	genCommitCmd.Flags().BoolVarP(&UseLLM, "use-llm", "l", false, "Use local LLM to auto-fill parts of the commit details")
 }

--- a/internal/commit/git.go
+++ b/internal/commit/git.go
@@ -1,0 +1,31 @@
+package commit
+
+import (
+	"os/exec"
+	"strings"
+)
+
+func getChangedFiles() ([]string, error) {
+	diffFilesCmd := exec.Command("git", "diff", "HEAD", "--name-only")
+	output, err := diffFilesCmd.Output()
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(output) == 0 {
+		return []string{}, nil
+	}
+
+	trimmedOutput := strings.TrimSpace(string(output))
+	return strings.Split(trimmedOutput, "\n"), nil
+}
+
+func getDiff(file string) (string, error) {
+	diffCmd := exec.Command("git", "diff", "HEAD", file)
+	output, err := diffCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	return string(output), nil
+}

--- a/internal/commit/llm.go
+++ b/internal/commit/llm.go
@@ -1,0 +1,71 @@
+package commit
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+)
+
+type LLMMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type LLMResponse struct {
+	Message LLMMessage `json:"message"`
+}
+
+type LLMClient struct {
+	messageHistory []LLMMessage
+}
+
+func (client *LLMClient) SendStandaloneMessage(prompt string) (string, error) {
+	options, buffer := map[string]interface{}{
+		"model":  "llama3.1",
+		"prompt": prompt,
+		"stream": false,
+	}, new(bytes.Buffer)
+
+	if err := json.NewEncoder(buffer).Encode(options); err != nil {
+		return "", err
+	}
+
+	resp, err := http.Post("http://localhost:11434/api/generate", "application/json", buffer)
+	if err != nil {
+		return "", err
+	}
+
+	defer resp.Body.Close()
+	var llmResp map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
+		return "", err
+	}
+
+	return llmResp["response"].(string), nil
+}
+
+func (client *LLMClient) SendChatMessage(message LLMMessage) (*LLMMessage, error) {
+	client.messageHistory = append(client.messageHistory, message)
+	options, buffer := map[string]interface{}{
+		"model":    "llama3.1",
+		"messages": client.messageHistory,
+		"stream":   false,
+	}, new(bytes.Buffer)
+
+	if err := json.NewEncoder(buffer).Encode(options); err != nil {
+		return nil, err
+	}
+
+	resp, err := http.Post("http://localhost:11434/api/chat", "application/json", buffer)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	var llmResp LLMResponse
+	if err := json.NewDecoder(resp.Body).Decode(&llmResp); err != nil {
+		return nil, err
+	}
+
+	return &llmResp.Message, nil
+}

--- a/internal/commit/prompts/git_commit_generation.txt
+++ b/internal/commit/prompts/git_commit_generation.txt
@@ -1,0 +1,17 @@
+"""
+You are tasked with generating a JSON object representing a Conventional Commit message.
+The outputted JSON object should have the following properties:
+
+* `type`: a string representing the type of commit (e.g., "feat", "fix", "docs", etc.)
+* `description`: a string representing a brief description of the commit
+* `scope`: a string representing the scope of the commit (optional)
+* `body`: a string representing a longer description of the commit (optional)
+* `breakingChange`: a string representing a description of any breaking changes (optional)
+
+In order to generate this JSON, you will be provided with summaries of changes made. You must continue asking for all the summaries until the user responds with the text “done”.
+Once you see this text, output the Conventional Commit JSON as previously mentioned. Each summary will be provided as a paragraph of text.
+
+The summaries the you must use will be provided as separate inputs, and you should analyze all of them to generate
+the corresponding JSON object. Do not generate code to generate this object. You must only use the given summaries.
+Until you see the text “done”, do not respond with any text other than the “next”.
+"""

--- a/internal/commit/prompts/git_diff_summary.txt
+++ b/internal/commit/prompts/git_diff_summary.txt
@@ -1,0 +1,2 @@
+Provide a brief summary of the following git diff. Your summary should include an overarching statement encapsulating the changes, followed by a few bullet points elaborating on individual points.
+Your response should be a paragraph describing the changes in the code, no longer than 5 sentences. Your response should not contain any markdown code fences and should just return the paragraph.


### PR DESCRIPTION
Allows for using local Ollama Llama 3.1 8b models to auto-generate a Conventional Commit style commit message based on the git diffs of the current directory. This will be modified in future versions to allow for more configuration such as changing the underlying model, allowing commit message generation to happen for any directory, and for displaying loading indicators.